### PR TITLE
update docker build script to include platform tag

### DIFF
--- a/build
+++ b/build
@@ -1,5 +1,5 @@
 IMAGE=quay.io/redhat-appstudio/dance-bootstrap-app
 
-docker.exe build . -t "$IMAGE"
+docker build --platform linux/amd64 . -t "$IMAGE"
 docker push "$IMAGE"
  


### PR DESCRIPTION
building on Mac arm architecture will cause exec issues in the container. 
update docker build script to include platform tag `--platform linux/amd64`